### PR TITLE
Ajustando y agregando tests para evitar falsos positivos y cubrir más casos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 node_modules
 npm-debug.log
 
+package-lock.json
+
 .vscode

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "chai": "^3.5.0",
-    "mocha": "^3.4.1"
+    "chai": "^4.1.2",
+    "mocha": "^5.0.4"
   }
 }

--- a/src/promise.js
+++ b/src/promise.js
@@ -16,4 +16,4 @@ function FiqusPromise(resolver) {
   resolver(fulfill, reject);
 }
 
-module.exports = { FiqusPromise }
+module.exports = FiqusPromise;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,4 +1,4 @@
-const { FiqusPromise } = require("./../src/promise");
+const FiqusPromise = require("./../src/promise");
 
 //executes the fn asynchronously
 function asyncTask(fn) {
@@ -6,17 +6,17 @@ function asyncTask(fn) {
 }
 
 function times(n, fn) {
-  for(let i = 0; i < n; i++) {
-    fn();
+  for(let idx = 1; idx <= n; idx++) {
+    fn(idx);
   }
 }
 
-function someError() {
-  return new Error("someError");
+function someError(message = "someError") {
+  return new Error(message);
 }
 
 //creates a promise that is resolved synchronously
-function syncronicPromiseFactory(value, {rejected = false, PromiseConstructor = FiqusPromise } = {}) {
+function synchronicPromiseFactory(value, {rejected = false, PromiseConstructor = FiqusPromise} = {}) {
   return new PromiseConstructor((resolve, reject) => {
     if(!rejected) {
       resolve(value);
@@ -27,7 +27,7 @@ function syncronicPromiseFactory(value, {rejected = false, PromiseConstructor = 
 }
 
 //creates a promise that is resolved asynchronously
-function asyncronicPromiseFactory(value, {rejected = false, PromiseConstructor = FiqusPromise } = {}) {
+function asynchronicPromiseFactory(value, {rejected = false, PromiseConstructor = FiqusPromise} = {}) {
   return new PromiseConstructor((resolve, reject) => {
     asyncTask(function() {
       if(!rejected) {
@@ -36,12 +36,12 @@ function asyncronicPromiseFactory(value, {rejected = false, PromiseConstructor =
         reject(someError());
       } 
     });
-  });;
+  });
 }
 
 module.exports = {
-  asyncronicPromiseFactory,
-  syncronicPromiseFactory,
+  asynchronicPromiseFactory,
+  synchronicPromiseFactory,
   someError,
   times
-}
+};

--- a/test/promise.test.js
+++ b/test/promise.test.js
@@ -1,7 +1,6 @@
-const chai = require("chai");
-const { FiqusPromise } = require("./../src/promise");
-const expect = chai.expect; 
-const {   asyncronicPromiseFactory, syncronicPromiseFactory, someError, times } = require("./helpers")
+const expect = require("chai").expect,
+  FiqusPromise = require("./../src/promise"),
+  { asynchronicPromiseFactory, synchronicPromiseFactory, someError, times } = require("./helpers");
 
 describe('NodePromise', suite(Promise));
 describe('FiqusPromise', suite(FiqusPromise));
@@ -13,137 +12,235 @@ describe('FiqusPromise', suite(FiqusPromise));
 function suite(PromiseConstructor) {
   return function() {
       let promise = null;
+      this.timeout(100);
   
-      describe("then()", function() {
+      describe("then()", () => {
         
-        it("should resolve syncronic values", function() {
-          const promise = syncronicPromiseFactory(1, { PromiseConstructor });
-          
-          return promise.then((v) => { 
-            expect(v).to.eql(1);
-          });
-        });
-        
-        it("should resolve asyncronic values", function() {
-          const promise = asyncronicPromiseFactory(1, { PromiseConstructor });
-          
-          return promise.then((v) => { 
-            expect(v).to.eql(1);
-          });
-        });
-
-        it("should resolve multiple handlers for then()", function() {
-          let promise = asyncronicPromiseFactory(1, { PromiseConstructor });
-          
-          times(5, function() {
-            promise = promise.then((v) => {
-              expect(v).to.eql(1);
-              return v;
-            });
-          })
-
-          return promise;
-        });
-
-        it("should resolve values returned in then()", function() {
-          const promise = asyncronicPromiseFactory(1, { PromiseConstructor });
-          
-          return promise.then((v) => { 
-            return v + 1;
-          }).then((newValue) => {
-            expect(newValue).to.eql(2);
-          });
-        });
-
-        it("should resolve values returned as Promises in then()", function() {
-          const promise = asyncronicPromiseFactory(1, { PromiseConstructor });
-          
-          return promise.then((v) => { 
-            return asyncronicPromiseFactory(v + 1, { PromiseConstructor });
-          }).then((newValue) => {
-            expect(newValue).to.eql(2);
-          });
-        });
-
-        it("should resolve values independently", function(done) {
-          const promise = asyncronicPromiseFactory(1, { PromiseConstructor });
+        it("should resolve synchronic values", (done) => {
+          const promise = synchronicPromiseFactory(1, {PromiseConstructor});
           
           promise.then((v) => { 
             expect(v).to.eql(1);
+            done();
+          });
+        });
+        
+        it("should resolve asynchronic values", (done) => {
+          const promise = asynchronicPromiseFactory(1, {PromiseConstructor});
+          
+          promise.then((v) => { 
+            expect(v).to.eql(1);
+            done();
+          });
+        });
+
+        it("should resolve multiple handlers", (done) => {
+          let promise = asynchronicPromiseFactory(1, {PromiseConstructor});
+          
+          times(5, function(idx) {
+            promise = promise.then((v) => {
+              expect(v).to.eql(1);
+              if (idx == 5) return done();
+              return v;
+            });
+          });
+        });
+
+        it("should resolve values returned in then()", (done) => {
+          const promise = asynchronicPromiseFactory(1, {PromiseConstructor});
+          
+          promise.then((v) => {
             return v + 1;
-          }).catch(done);
+          })
+          .then((newValue) => {
+            expect(newValue).to.eql(2);
+            done();
+          });
+        });
+
+        it("should resolve values independently without affecting the original promise", (done) => {
+          const promise = asynchronicPromiseFactory(1, {PromiseConstructor});
+          
+          promise.then((v) => {
+            return v + 1;
+          });
 
           setTimeout(() => {
             promise.then((v) => {
               expect(v).to.eql(1);
-            })
-            .then(done)
-            .catch(done)
+              done();
+            });
+          });
+        });
+
+        it("should get undefined in the next then() if nothing is returned in the previous one", (done) => {
+          const promise = asynchronicPromiseFactory(1, {PromiseConstructor});
+          
+          promise.then((v) => {
+            expect(v).to.eql(1);
           })
-
+          .then((shouldBeUndefined) => {
+            expect(shouldBeUndefined).to.eql(undefined);
+            done();
+          });
         });
-        
+
+        it("should resolve values returned as promises", (done) => {
+          const promise = asynchronicPromiseFactory(1, {PromiseConstructor});
+          
+          promise.then((v) => { 
+            return asynchronicPromiseFactory(v + 1, {PromiseConstructor});
+          })
+          .then((newValue) => {
+            expect(newValue).to.eql(2);
+            done();
+          });
+        });
+
+        it("should resolve values returned as functions", (done) => {
+          const promise = asynchronicPromiseFactory(1, {PromiseConstructor});
+          
+          promise.then((v) => { 
+            return (val) => {
+              return v + val;
+            };
+          })
+          .then((func) => {
+            expect(func(3)).to.eql(4);
+            done();
+          });
+        });
+
+        it("should resolve values returned as a function returning a promise", (done) => {
+          const promise = asynchronicPromiseFactory(1, {PromiseConstructor});
+          
+          promise.then((v) => { 
+            return (val) => {
+              return asynchronicPromiseFactory(val + v + 10, {PromiseConstructor});
+            };
+          })
+          .then((func) => {
+            return func(3).then((val) => {
+              expect(val).to.eql(14);
+              return val - 2;
+            });
+          })
+          .then((val) => {
+            expect(val).to.eql(12);
+            done();
+          });
+        });
+
       });
       
-      describe("catch()", function() {
-      
-        it("should return error if rejected", function() {
-          const promise = asyncronicPromiseFactory(null, {rejected: true, PromiseConstructor});
+      describe("catch()", () => {
+
+        it("should return error if rejected and don't call then() defined before catch()", (done) => {
+          const promise = asynchronicPromiseFactory(null, {rejected: true, PromiseConstructor});
           
-          return promise
-            .then(() => { 
-              //this line should not be called!
-              expect(true).to.eql(false);
-            })
-            .catch((err) => {
-              expect(err.message).to.eql("someError");
-            })
+          promise.then(() => { 
+            done("This line should not be called!");
+          })
+          .catch((err) => {
+            expect(err.message).to.eql("someError");
+            done();
+          });
         });
 
-        it("after catch() you can use then()", function(done) {
-          const promise = asyncronicPromiseFactory(null, {rejected: true, PromiseConstructor});
+        it("after catch() you can use catch() again", (done) => {
+          const promise = asynchronicPromiseFactory(null, {rejected: true, PromiseConstructor});
           
-          promise
-            .catch((err) => {
-              expect(err.message).to.eql("someError");
-            })
-            .then(done);
+          promise.catch((err) => {
+            throw someError();
+          })
+          .catch((err) => {
+            expect(err.message).to.eql("someError");
+            done();
+          })
+          .catch(done);
+        });
+
+        it("after catch() you can use then() with the returned value", (done) => {
+          const promise = asynchronicPromiseFactory(null, {rejected: true, PromiseConstructor});
+          
+          promise.catch((err) => {
+            return err.message;
+          })
+          .then((errMsg) => {
+            expect(errMsg).to.eql("someError");
+            done();
+          })
+          .catch(done);
         });
 
       });
 
-      describe("then() and catch()", function() {
+      describe("then() and catch()", () => {
 
-        it("if then() throws synchronically catch() should handle", function(done) {
-          const promise = syncronicPromiseFactory(1, {PromiseConstructor});
+        it("if then() throws synchronically catch() should handle", (done) => {
+          const promise = synchronicPromiseFactory(1, {PromiseConstructor});
           
-          promise
-            .then(() => {
-              throw someError();
+          promise.then(() => {
+            throw someError();
+          })
+          .catch((err) => {
+            expect(err.message).to.eql("someError");
+            done();
+          })
+          .catch(done);
+        });
+
+        it("if then() throws asynchronically catch() should handle", (done) => {
+          const promise = asynchronicPromiseFactory(1, {PromiseConstructor});
+          
+          promise.then(() => {
+            throw someError();
+          })
+          .catch((err) => {
+            expect(err.message).to.eql("someError");
+            done();
+          })
+          .catch(done);
+        });
+
+        it("should be able to catch an error produced on an inner promise's then", (done) => {
+          const promise = asynchronicPromiseFactory(1, {PromiseConstructor});
+          
+          promise.then((v) => {
+            return asynchronicPromiseFactory(v + 1, {PromiseConstructor}).then((val) => {
+              expect(val).to.eql(10);
+            });
+          })
+          .catch((err) => {
+            expect(err.actual).to.eql(2);
+            expect(err.expected).to.eql(10);
+            done();
+          })
+          .catch(done);
+        });
+
+        it("should be able to catch an error produced on an inner promise's catch", (done) => {
+          const promise = asynchronicPromiseFactory(1, {PromiseConstructor});
+          
+          promise.then((v) => {
+            return asynchronicPromiseFactory(v + 1, {rejected: true, PromiseConstructor}).then(() => {
+              done("This line should not be called!");
             })
             .catch((err) => {
-              expect(err.message).to.eql("someError");
-              done();
-            })
-            .catch(done)
+              expect(err.message).to.eql("someAnotherError");
+            });
+          })
+          .then(() => {
+            done("This line should not be called!");
+          })
+          .catch((err) => {
+            expect(err.actual).to.eql("someError");
+            expect(err.expected).to.eql("someAnotherError");
+            done();
+          })
+          .catch(done);
+        });
 
-        })
-
-        it("if then() throws asynchronically catch() should handle", function(done) {
-          const promise = asyncronicPromiseFactory(1, {PromiseConstructor});
-          
-          promise
-            .then(() => {
-              throw someError();
-            })
-            .catch((err) => {
-              expect(err.message).to.eql("someError");
-              done();
-            })
-            .catch(done)
-        })
-
-      })
+      });
   }
 }
-

--- a/test/promise.test.js
+++ b/test/promise.test.js
@@ -242,5 +242,108 @@ function suite(PromiseConstructor) {
         });
 
       });
+
+      describe("resolve() and reject()", () => {
+
+        it("should call then() after Promise.resolve()", (done) => {
+          PromiseConstructor.resolve(11)
+            .catch(() => {
+              done("This line should not be called!");
+            })
+            .then((v) => {
+              expect(v).to.eql(11);
+              done();
+            })
+            .catch(done);
+        });
+
+        it("should call catch() after Promise.reject()", (done) => {
+          PromiseConstructor.reject(11)
+            .then(() => {
+              done("This line should not be called!");
+            })
+            .catch((v) => {
+              expect(v).to.eql(11);
+              done();
+            })
+            .catch(done);
+        });
+
+        it("should call catch() after Promise.resolve() with a rejected promise", (done) => {
+          PromiseConstructor.resolve(PromiseConstructor.reject(someError()))
+            .then(() => {
+              done("This line should not be called!");
+            })
+            .catch((err) => {
+              expect(err.message).to.eql("someError");
+              done();
+            })
+            .catch(done);
+        });
+
+        it("should call catch() after Promise.reject() with a resolved promise", (done) => {
+          let confirm = 0;
+
+          PromiseConstructor.reject(PromiseConstructor.resolve(22))
+            .then(() => {
+              done("This line should not be called!");
+            })
+            .catch((promise) => {
+              confirm++;
+              return promise;
+            })
+            .then((v) => {
+              expect(confirm).to.eql(1);
+              expect(v).to.eql(22);
+              done();
+            })
+            .catch(done);
+        });
+
+        it("should call catch() after Promise.reject() with a function returning a resolved promise", (done) => {
+          let confirm = 0;
+
+          PromiseConstructor.reject(() => {
+              return PromiseConstructor.resolve(22);
+            })
+            .then(() => {
+              done("This line should not be called!");
+            })
+            .catch((func) => {
+              confirm++;
+              return func()
+                .catch(() => {
+                  done("This line should not be called!");
+                });
+            })
+            .then((v) => {
+              expect(confirm).to.eql(1);
+              expect(v).to.eql(22);
+              done();
+            })
+            .catch(done);
+        });
+
+        it("should call then() after Promise.resolve() with a function returning a rejected promise", (done) => {
+          PromiseConstructor.resolve(() => {
+              return PromiseConstructor.reject(someError());
+            })
+            .catch(() => {
+              done("This line should not be called!");
+            })
+            .then((func) => {
+              return func()
+                .then(() => {
+                  done("This line should not be called!");
+                })
+                .catch((err) => {
+                  expect(err.message).to.eql("someError");
+                  done();
+                });
+            })
+            .catch(done);
+        });
+
+      });
   }
 }


### PR DESCRIPTION
**Aclaraciones:**
* En todos los tests agregué el uso de "done" para evitar falsos positivos que se "tragan" posibles errores en expect y demases. Además así queda más explícito cuándo/dónde termina el test.
* En los tests de .then() NO agregué el .catch(done) por que todavía no se está testeando el "catch", por lo tanto si fallan los tests podrían tirar timeout.
* En algunos tests que tenían el .catch(done) se los saqué para que haya UNA sola llamada a done() y asegurar que salga sólo por ese punto y no por un catch que le pase a done() algo que haga correr el test OK.

**Mensaje de commit:**
* Ajustando y agregando casos en promise.test.js para evitar falsos positivos. Utilizando done() en todos los tests para ser explícitos en los puntos en donde el test debe finalizar OK o fallar.
* Cambiando promise.js para que el module.exports sea directamente FiqusPromise en lugar de un objeto.
* Pequeños ajustes en helpers.js.
* Actualizando versiones de chai y mocha en package.json.